### PR TITLE
List repository urls

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -318,6 +318,57 @@ const docTemplate = `{
                 }
             }
         },
+        "/repositories/urls/": {
+            "get": {
+                "description": "list repository URLs",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "repositories"
+                ],
+                "summary": "List Repository URLs",
+                "operationId": "listRepositoryURLs",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/repositories/{uuid}": {
             "get": {
                 "description": "Get information about a Repository",

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -822,6 +822,71 @@
                 ]
             }
         },
+        "/repositories/urls/": {
+            "get": {
+                "description": "list repositories URLs",
+                "operationId": "listRepositoriesURLs"
+            },
+            "responses": {
+                "200": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "description": "OK"
+                },
+                "400": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/errors.ErrorResponse"
+                            }
+                        }
+                    },
+                    "description": "Bad Request"
+                },
+                "401": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/errors.ErrorResponse"
+                            }
+                        }
+                    },
+                    "description": "Unauthorized"
+                },
+                "404": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/errors.ErrorResponse"
+                            }
+                        }
+                    },
+                    "description": "Not Found"
+                },
+                "500": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/errors.ErrorResponse"
+                            }
+                        }
+                    },
+                    "description": "Internal Server Error"
+                }
+            },
+            "summary": "List Repository URLs",
+            "tags": [
+                "repositories"
+            ]
+        },
         "/repositories/bulk_create/": {
             "post": {
                 "description": "bulk create repositories",

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -822,71 +822,6 @@
                 ]
             }
         },
-        "/repositories/urls/": {
-            "get": {
-                "description": "list repositories URLs",
-                "operationId": "listRepositoriesURLs"
-            },
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "description": "OK"
-                },
-                "400": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/errors.ErrorResponse"
-                            }
-                        }
-                    },
-                    "description": "Bad Request"
-                },
-                "401": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/errors.ErrorResponse"
-                            }
-                        }
-                    },
-                    "description": "Unauthorized"
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/errors.ErrorResponse"
-                            }
-                        }
-                    },
-                    "description": "Not Found"
-                },
-                "500": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/errors.ErrorResponse"
-                            }
-                        }
-                    },
-                    "description": "Internal Server Error"
-                }
-            },
-            "summary": "List Repository URLs",
-            "tags": [
-                "repositories"
-            ]
-        },
         "/repositories/bulk_create/": {
             "post": {
                 "description": "bulk create repositories",
@@ -970,6 +905,71 @@
                     }
                 },
                 "summary": "Bulk create repositories",
+                "tags": [
+                    "repositories"
+                ]
+            }
+        },
+        "/repositories/urls/": {
+            "get": {
+                "description": "list repository URLs",
+                "operationId": "listRepositoryURLs",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "List Repository URLs",
                 "tags": [
                     "repositories"
                 ]

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -34,6 +34,7 @@ type RepositoryConfigDao interface {
 	Update(orgID string, uuid string, repoParams api.RepositoryRequest) error
 	Fetch(orgID string, uuid string) (api.RepositoryResponse, error)
 	List(orgID string, paginationData api.PaginationData, filterData api.FilterData) (api.RepositoryCollectionResponse, int64, error)
+	ListURLs(OrgID string) ([]string, error)
 	Delete(orgID string, uuid string) error
 	SavePublicRepos(urls []string) error
 	ValidateParameters(orgId string, params api.RepositoryValidationRequest, excludedUUIDS []string) (api.RepositoryValidationResponse, error)

--- a/pkg/dao/repository_config_mock.go
+++ b/pkg/dao/repository_config_mock.go
@@ -73,6 +73,32 @@ func (r *MockRepositoryConfigDao) List(
 	}
 }
 
+// ListURLs provides a mock function with given fields: OrgID
+func (_m *MockRepositoryConfigDao) ListURLs(OrgID string) ([]string, error) {
+	ret := _m.Called(OrgID)
+
+	var r0 []string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) ([]string, error)); ok {
+		return rf(OrgID)
+	}
+	if rf, ok := ret.Get(0).(func(string) []string); ok {
+		r0 = rf(OrgID)
+	} else {
+		if ret.Get(0) != nil {
+			r0, _ = ret.Get(0).([]string)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(OrgID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 func (r *MockRepositoryConfigDao) SavePublicRepos(urls []string) error {
 	return nil
 }

--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -359,6 +359,7 @@ func ModelToApiFields(repoConfig models.RepositoryConfiguration, apiRepo *api.Re
 	apiRepo.GpgKey = repoConfig.GpgKey
 	apiRepo.MetadataVerification = repoConfig.MetadataVerification
 	apiRepo.FailedIntrospectionsCount = repoConfig.Repository.FailedIntrospectionsCount
+	apiRepo.RepositoryUUID = repoConfig.RepositoryUUID
 
 	if repoConfig.Repository.LastIntrospectionTime != nil {
 		apiRepo.LastIntrospectionTime = repoConfig.Repository.LastIntrospectionTime.Format(time.RFC3339)

--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -156,7 +156,8 @@ func (r repositoryConfigDaoImpl) bulkCreate(tx *gorm.DB, newRepositories []api.R
 
 func (r repositoryConfigDaoImpl) ListURLs(OrgId string) ([]string, error) {
 	var urls []string
-	result := r.db.Model(models.RepositoryConfiguration{}).Where("org_id = ?", OrgId).Joins("inner join repositories on repository_configurations.repository_uuid = repositories.uuid").Select("URL").Find(&urls)
+	result := r.db.Model(models.RepositoryConfiguration{}).Where("org_id = ?", OrgId).
+		Joins("inner join repositories on repository_configurations.repository_uuid = repositories.uuid").Select("URL").Find(&urls)
 	if result.Error != nil {
 		return urls, result.Error
 	}

--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -154,6 +154,15 @@ func (r repositoryConfigDaoImpl) bulkCreate(tx *gorm.DB, newRepositories []api.R
 	}
 }
 
+func (r repositoryConfigDaoImpl) ListURLs(OrgId string) ([]string, error) {
+	var urls []string
+	result := r.db.Model(models.RepositoryConfiguration{}).Where("org_id = ?", OrgId).Joins("inner join repositories on repository_configurations.repository_uuid = repositories.uuid").Select("URL").Find(&urls)
+	if result.Error != nil {
+		return urls, result.Error
+	}
+	return urls, nil
+}
+
 func (r repositoryConfigDaoImpl) List(
 	OrgID string,
 	pageData api.PaginationData,
@@ -349,7 +358,6 @@ func ModelToApiFields(repoConfig models.RepositoryConfiguration, apiRepo *api.Re
 	apiRepo.GpgKey = repoConfig.GpgKey
 	apiRepo.MetadataVerification = repoConfig.MetadataVerification
 	apiRepo.FailedIntrospectionsCount = repoConfig.Repository.FailedIntrospectionsCount
-	apiRepo.RepositoryUUID = repoConfig.RepositoryUUID
 
 	if repoConfig.Repository.LastIntrospectionTime != nil {
 		apiRepo.LastIntrospectionTime = repoConfig.Repository.LastIntrospectionTime.Format(time.RFC3339)

--- a/pkg/dao/repository_configs_test.go
+++ b/pkg/dao/repository_configs_test.go
@@ -1041,6 +1041,17 @@ func (suite *RepositoryConfigSuite) TestListURLs() {
 	if len(response) > 0 {
 		assert.Equal(t, repoConfig.Repository.URL, response[0])
 	}
+
+	var otherOrgTotal int64
+	otherOrgID := orgID + "a"
+	otherOrgResponse, otherOrgErr := GetRepositoryConfigDao(suite.tx).ListURLs(otherOrgID)
+	otherOrgRepoConfigs := make([]models.RepositoryConfiguration, 0)
+	otherOrgResult := suite.tx.Where("org_id = ?", otherOrgID).Find(&otherOrgRepoConfigs).Count(&otherOrgTotal)
+
+	assert.Nil(t, otherOrgResult.Error)
+	assert.Nil(t, otherOrgErr)
+	assert.Empty(t, otherOrgResponse)
+	assert.Equal(t, int64(0), otherOrgTotal)
 }
 
 func (suite *RepositoryConfigSuite) TestListURLsNoRepositories() {

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -48,6 +48,7 @@ func RegisterRepositoryRoutes(engine *echo.Group, daoReg *dao.DaoRegistry, prod 
 		TaskClient:                *taskClient,
 	}
 	engine.GET("/repositories/", rh.listRepositories)
+	engine.GET("/repositories/urls/", rh.listRepositoryURLs)
 	engine.GET("/repositories/:uuid", rh.fetch)
 	engine.PUT("/repositories/:uuid", rh.fullUpdate)
 	engine.PATCH("/repositories/:uuid", rh.partialUpdate)
@@ -114,6 +115,29 @@ func (rh *RepositoryHandler) listRepositories(c echo.Context) error {
 	}
 
 	return c.JSON(200, setCollectionResponseMetadata(&repos, c, totalRepos))
+}
+
+// ListRepositoryURLs godoc
+// @Summary      List Repository URLs
+// @ID           listRepositoryURLs
+// @Description  list repository URLs
+// @Tags         repositories
+// @Accept       json
+// @Produce      json
+// @Success      200 {[]string} Repository URLs
+// @Failure      400 {object} ce.ErrorResponse
+// @Failure      401 {object} ce.ErrorResponse
+// @Failure      404 {object} ce.ErrorResponse
+// @Failure      500 {object} ce.ErrorResponse
+// @Router       /repositories/urls/ [get]
+func (rh *RepositoryHandler) listRepositoryURLs(c echo.Context) error {
+	_, orgId := getAccountIdOrgId(c)
+	urls, err := rh.DaoRegistry.RepositoryConfig.ListURLs(orgId)
+	if err != nil {
+		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error listing repository URLs", err.Error())
+	}
+
+	return c.JSON(http.StatusOK, urls)
 }
 
 // CreateRepository godoc

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -124,7 +124,7 @@ func (rh *RepositoryHandler) listRepositories(c echo.Context) error {
 // @Tags         repositories
 // @Accept       json
 // @Produce      json
-// @Success      200 {[]string} Repository URLs
+// @Success      200 {object} []string
 // @Failure      400 {object} ce.ErrorResponse
 // @Failure      401 {object} ce.ErrorResponse
 // @Failure      404 {object} ce.ErrorResponse

--- a/pkg/handler/repositories_test.go
+++ b/pkg/handler/repositories_test.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"bytes"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -307,37 +306,6 @@ func (suite *ReposSuite) TestListURLsSimple() {
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(response))
 	assert.Equal(t, urls[0], response[0])
-
-	// Makes sure that users with a different organization ID don't see the urls
-	otherOrgId := test_handler.MockOrgId + "a"
-	otherAccountNumber := test_handler.MockAccountNumber + "1"
-	suite.reg.RepositoryConfig.On("ListURLs", otherOrgId).Return([]string{}, nil)
-
-	otherOrgMockIdentity := identity.XRHID{
-		Identity: identity.Identity{
-			AccountNumber: otherAccountNumber,
-			Internal: identity.Internal{
-				OrgID: otherOrgId,
-			},
-			Type: "Associate",
-		},
-	}
-	otherOrgJsonIdentity, err := json.Marshal(otherOrgMockIdentity)
-	if err != nil {
-		t.Error("Could not marshal JSON")
-	}
-
-	otherOrgReq := httptest.NewRequest(http.MethodGet, fullRootPath()+"/repositories/urls/", nil)
-	otherOrgReq.Header.Set(api.IdentityHeader, base64.StdEncoding.EncodeToString(otherOrgJsonIdentity))
-
-	otherOrgCode, otherOrgBody, otherOrgErr := suite.serveRepositoriesRouter(otherOrgReq)
-	assert.Nil(t, otherOrgErr)
-	assert.Equal(t, http.StatusOK, otherOrgCode)
-
-	var otherOrgResponse []string
-	err = json.Unmarshal(otherOrgBody, &otherOrgResponse)
-	assert.Nil(t, err)
-	assert.Equal(t, 0, len(otherOrgResponse))
 }
 
 func (suite *ReposSuite) TestListURLsNoRepositories() {

--- a/pkg/handler/repositories_test.go
+++ b/pkg/handler/repositories_test.go
@@ -283,6 +283,53 @@ func (suite *ReposSuite) TestListDaoError() {
 	assert.Equal(t, http.StatusInternalServerError, code)
 }
 
+func (suite *ReposSuite) TestListURLsSimple() {
+	t := suite.T()
+
+	collection := createRepoCollection(1, 10, 0)
+	urls := make([]string, len(collection.Data))
+	for i := range collection.Data {
+		urls[i] = collection.Data[i].URL
+	}
+
+	suite.reg.RepositoryConfig.On("ListURLs", test_handler.MockOrgId).Return(urls, nil)
+
+	// Makes sure that users with a different organization ID don't the urls
+	otherOrgId := test_handler.MockOrgId + "a"
+	suite.reg.RepositoryConfig.On("ListURLs", otherOrgId).Return([]string{}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, fullRootPath()+"/repositories/urls/", nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, body, err := suite.serveRepositoriesRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, code)
+
+	var response []string
+	err = json.Unmarshal(body, &response)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(response))
+	assert.Equal(t, urls[0], response[0])
+}
+
+func (suite *ReposSuite) TestListURLsNoRepositories() {
+	t := suite.T()
+
+	suite.reg.RepositoryConfig.On("ListURLs", test_handler.MockOrgId).Return([]string{}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, fullRootPath()+"/repositories/urls/", nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, body, err := suite.serveRepositoriesRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, code)
+
+	var response []string
+	err = json.Unmarshal(body, &response)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(response))
+}
+
 func (suite *ReposSuite) TestFetch() {
 	t := suite.T()
 


### PR DESCRIPTION
## Summary

Adds an endpoint to get all the repository URLs for an organization at 
`GET  /api/content-sources/v1.0/repositories/urls/`

## Testing steps

